### PR TITLE
Added Highlighting

### DIFF
--- a/resources/views/tile.blade.php
+++ b/resources/views/tile.blade.php
@@ -1,24 +1,24 @@
 <x-dashboard-tile :position="$position">
     <h1>{{ $standings['competition']['name'] }}</h1>
-    <table class="table-fixed border text-xs">
+    <table class="text-xs border table-fixed">
         <thead>
         <tr>
-            <th>#</th>
-            <th></th>
-            <th>Team</th>
-            <th>Points</th>
-            <th>Goals</th>
+            <th class="px-1">#</th>
+            <th class="px-1"></th>
+            <th class="px-1">Team</th>
+            <th class="px-1">Points</th>
+            <th class="px-1">Goals</th>
         </tr>
         </thead>
         <tbody>
 
     @foreach($standings['standings'][0]['table'] as $rank)
-            <tr>
-                <td class="border">{{ $rank['position']}}</td>
-                <td class="border"><img style="height: 20px;" src="{{ $rank['team']['crestUrl'] }}" alt="{{ $rank['team']['name']}}"></td>
-                <td class="border">{{ $rank['team']['name']}}</td>
-                <td class="border">{{ $rank['points']}}</td>
-                <td class="border">{{ $rank['goalsFor'] . ' : ' . $rank['goalsAgainst'] }}</td>
+            <tr class="{{ $rank['team']['id'] === $highlight ? 'bg-gray-200 font-semibold' : '' }}">
+                <td class="px-1 text-center border">{{ $rank['position']}}</td>
+                <td class="flex justify-center px-1 border"><img style="height: 20px;" src="{{ $rank['team']['crestUrl'] }}" alt="{{ $rank['team']['name']}}"></td>
+                <td class="px-1 border">{{ $rank['team']['name']}}</td>
+                <td class="px-1 text-center border">{{ $rank['points']}}</td>
+                <td class="px-1 border">{{ $rank['goalsFor'] . ' : ' . $rank['goalsAgainst'] }}</td>
             </tr>
     @endforeach
 

--- a/src/FootballStandingsTileComponent.php
+++ b/src/FootballStandingsTileComponent.php
@@ -9,9 +9,13 @@ class FootballStandingsTileComponent extends Component
     /** @var string */
     public $position;
 
-    public function mount(string $position)
+    /** @var integer */
+    public $highlight;
+
+    public function mount(string $position, int $highlight = null)
     {
         $this->position = $position;
+        $this->highlight = $highlight;
     }
 
     public function render()
@@ -19,7 +23,8 @@ class FootballStandingsTileComponent extends Component
         $footballStandingsStore = FootballStandingsStore::make();
 
         return view('dashboard-football-standings-tile::tile', [
-            'standings' => $footballStandingsStore->footballStandings()
+            'standings' => $footballStandingsStore->footballStandings(),
+            'highlight' => $this->highlight,
         ]);
     }
 }


### PR DESCRIPTION
An optional `$highlight`-attribute to the tile triggers a simple highlighting of e.g. the local or favourite team. I expect this to be a common use case for the tile.

For simplicity, this commit uses the `id` of the team, specific to every competition -- "4" in this case for BVB @ 1. Bundesliga.

This is simply done in the Blade-file like this:
```
        <x-dashboard>
            <livewire:football-standings-tile position="a1" highlight="4" />
            <livewire:football-standings-tile position="b1" />
        </x-dashboard>
```

I also added some paddings and alignment to the table, resulting in this:
![image](https://user-images.githubusercontent.com/930553/80863870-687d5180-8c7f-11ea-8ec8-9ed9024bed4a.png)
